### PR TITLE
Fix typo in “version ahead of published” message

### DIFF
--- a/lib/utils/messages.js
+++ b/lib/utils/messages.js
@@ -32,7 +32,7 @@ exports.aheadOfPublished = function() {
   ———————————————————————————————————————————————————————————
 
   The version of ${chalk.green('create-ueno-app')} you are
-  using is aheah on the npm one.
+  using is ahead of the npm one.
 
   ———————————————————————————————————————————————————————————
   `);


### PR DESCRIPTION
Based on the name of the function, I think my correction is correct :sweat_smile:

Let me know if y’all want any changes!